### PR TITLE
Removed the Android 12+ devices default splash screen.

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -4,8 +4,10 @@
     <c:release date="2023-10-27T00:00:00+00:00" is-open="false" ticket-system="org.thepalaceproject.jira" version="1.0.0">
       <c:changes/>
     </c:release>
-    <c:release date="2023-10-27T16:37:29+00:00" is-open="true" ticket-system="org.thepalaceproject.jira" version="1.1.0">
-      <c:changes/>
+    <c:release date="2023-10-30T12:26:04+00:00" is-open="true" ticket-system="org.thepalaceproject.jira" version="1.1.0">
+      <c:changes>
+        <c:change date="2023-10-30T12:26:04+00:00" summary="Removed the Android 12+ devices default splash screen."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.androidx.core.common)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.runtime)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.cursoradapter)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.customview.poolingcontainer)

--- a/core/src/main/res/values-v31/themes.xml
+++ b/core/src/main/res/values-v31/themes.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
+    <style name="PalaceTheme" parent="PalaceTheme.WithoutActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+
+        <!-- The theme to set after the default splash screen is dismissed-->
+        <item name="postSplashScreenTheme">@style/PalaceTheme.WithoutActionBar</item>
+    </style>
+
     <style name="PalaceTheme.WithoutActionBar" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowBackground">@color/PalaceScreenBackgroundColor</item>
         <item name="android:fontFamily">@font/open_sans_regular</item>

--- a/core/src/main/res/values/themes.xml
+++ b/core/src/main/res/values/themes.xml
@@ -2,6 +2,8 @@
 
 <resources>
 
+    <style name="PalaceTheme" parent="PalaceTheme.WithoutActionBar" />
+
     <style name="PalaceTheme.WithActionBar" parent="Theme.Material3.DayNight">
         <item name="android:windowBackground">@color/PalaceScreenBackgroundColor</item>
         <item name="android:fontFamily">@font/open_sans_regular</item>

--- a/sandbox/build.gradle.kts
+++ b/sandbox/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(libs.androidx.core.common)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.runtime)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.cursoradapter)
     implementation(libs.androidx.customview)
     implementation(libs.androidx.customview.poolingcontainer)


### PR DESCRIPTION
**What's this do?**
This PR removes the default SplashScreen added in all the Android 12+ devices by setting a theme with a translucent status when launching the app on an Android 12+ (the other versions remain unchanged and with the original theme) and set the original app's theme when the default splash screen is dismissed.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://ebce-lyrasis.atlassian.net/browse/PP-585) saying that in some devices there are two splash screens being shown: the device's default and the app's splash screen.

**How should this be tested? / Do these changes have associated tests?**
Follow [this PR](https://github.com/ThePalaceProject/android-core/pull/249)'s reproducing steps

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-core/pull/249) needs to be merged to test this

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 